### PR TITLE
Revert android sdk version and min version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,10 +12,10 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 16
     }
 }
 


### PR DESCRIPTION
react-native@0.45.x and react-native-cli@2.0.1, the current stable releases of RN, scaffold a project declaring the android sdk version at 23 and the minsdk version at 16. So adding react-native-touch-sensor as a dependency conflicts, since it expects a minsdk version of 23.

I saw the minsdk change here https://github.com/Raizlabs/react-native-touch-sensor/commit/03dc215e7fe69c4a0989ef1682a5bbea43162a76, does the Android Fingerprint UI require minsdk >= 23? Does the library itself need to be compiled with sdk v23? I updated this dependency locally to build against sdk v23 with a minsdk of 16 and it built fine and seemed to run ok in the android simulator.

If these version constraints aren't required, can we merge this for compatibility with scaffolds generated by the current RN tools?